### PR TITLE
Adding plugin-descriptor.properties

### DIFF
--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -1,0 +1,4 @@
+description=analysis-url - enables URL tokenization and token filtering by URL part
+version=2.1.1
+site=true
+name=analysis-url


### PR DESCRIPTION
Without plugin-descriptor.properties file, when upgrading via Puppet, encounter the following errors -

Verifying https://github.com/jlinn/elasticsearch-analysis-url/releases/download/v2.0.0/elasticsearch-analysis-url-2.0.0.zip checksums if available ...
NOTE: Unable to verify checksum for downloaded plugin (unable to find .sha1 or .md5 file to verify)
ERROR: Could not find plugin descriptor 'plugin-descriptor.properties' in plugin zip> at 129:/etc/puppetlabs/code/environments/ec2/modules/elasticsearch/manifests/plugin.pp